### PR TITLE
add python3 to docker image to work with node-gyp

### DIFF
--- a/recording-oracle/Dockerfile
+++ b/recording-oracle/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /usr/src/app
 
 COPY package.json yarn.lock ./
 
+RUN apk add python3 make gcc g++
 RUN yarn
 
 COPY contracts ./contracts

--- a/reputation-oracle/Dockerfile
+++ b/reputation-oracle/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /usr/src/app
 
 COPY package.json yarn.lock ./
 
+RUN apk add python3 make gcc g++
 RUN yarn
 
 COPY contracts ./contracts


### PR DESCRIPTION
When doing docker-compose up, errors are thrown on recording/reputation-oracle, missing python for node-gyp dep.

![Capture d’écran 2022-04-21 à 15 35 21](https://user-images.githubusercontent.com/16646581/164485649-7040942a-d113-439f-a69b-b4e3675cc108.png)

Add python3 and other dep to docker build to avoid a node-gyp error.