### PR TITLE
Fix #35. Set fixed minio version in the docker-compose files

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,7 +10,7 @@ services:
       - 8547:8545
 
   minio-test:
-    image: quay.io/minio/minio
+    image: minio/minio:RELEASE.2022-05-26T05-48-41Z
     ports:
       - 9001:9001
       - 9000:9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - 8547:8545
 
   minio:
-    image: quay.io/minio/minio
+    image: minio/minio:RELEASE.2022-05-26T05-48-41Z
     ports:
       - 9001:9001
       - 9000:9000


### PR DESCRIPTION
The problem is when you deploy files using minio console or API
it uses a different format for storing these files after release RELEASE.2022-05-26T05-48-41Z
But what we do during the local run - is we simply passing a file to the
docker container and then do a `cp /tmp/docker-manifest.json
/data/manifests/manifest.json`.

So as a workaround for now, minio rolled back to the previous release
with original storing