### PR TITLE
add multiOS support

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -35,7 +35,7 @@ services:
       /bin/sh -c "
       /usr/bin/mc config host add myminio http://minio-test:9000 dev devdevdev;
       /usr/bin/mc mb myminio/manifests;
-      /usr/bin/mc policy set public myminio/manifests;
+      /usr/bin/mc anonymous set public myminio/manifests;
       /usr/bin/mc cp /tmp/manifests/docker-manifest.json myminio/manifests;
       "
 
@@ -56,6 +56,8 @@ services:
   recording-oracle-test:
     build:
       context: ./recording-oracle
+    extra_hosts:
+      - host.docker.internal:host-gateway
     ports:
       - 3005:3005
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,12 +38,15 @@ services:
   recording-oracle:
     build:
       context: ./recording-oracle
-    network_mode: "host"
+    extra_hosts:
+      - host.docker.internal:host-gateway
     environment:
       ETH_PRIVATE_KEY: 486a0621e595dd7fcbe5608cbbeec8f5a8b5cabe7637f11eccfc7acd408c3a0e
-      ETH_HTTP_SERVER: http://localhost:8547
+      ETH_HTTP_SERVER: http://ganache:8545
       PORT: 3005
     command: ["yarn", "start"]
+    ports:
+      - 3005:3005
 
   reputation-oracle:
     build:

--- a/recording-oracle/index.js
+++ b/recording-oracle/index.js
@@ -53,7 +53,7 @@ app.post('/job/results', async function(req, res) {
     }
 
     const manifestUrl = await Escrow.methods.manifestUrl().call({ from: account.address });
-    const manifestResponse = await axios.get(manifestUrl);
+    const manifestResponse = await axios.get(convertUrl(manifestUrl));
     const {fortunes_requested: fortunesRequested, reputation_oracle_url: reputationOracleUrl} = manifestResponse.data;
 
     if (!storage.getEscrow(escrowAddress)) {
@@ -74,7 +74,7 @@ app.post('/job/results', async function(req, res) {
       // a cron job might check how much annotations are in work
       // if this is full - then just push them to the reputation oracle
 
-      await axios.post(reputationOracleUrl, { escrowAddress, fortunes });
+      await axios.post(convertUrl(reputationOracleUrl), { escrowAddress, fortunes });
       storage.cleanFortunes(escrowAddress);
     }
 
@@ -86,6 +86,10 @@ app.post('/job/results', async function(req, res) {
     res.status(500).send(err);
   }
 });
+
+function convertUrl(url){
+  return url.replace('localhost', 'host.docker.internal');
+}
 
 app.listen(port, () => {
   console.log(`Recording Oracle server listening port ${port}`);


### PR DESCRIPTION
# Description
This project cannot be run on Windows

# Changes 
Instead of use network mode "host" for the Recording Oracle, a new hot has been added as "host.docker.internal" and the requests sent to this new host are sent to local machine host.
In the Recording Oracle, whenever we use a url that contains "localhost", it will be replaced by "host.docker.internal".
The command to set the bucket policy as "public" has been updated to make the tests work.


# How has been tested?
- [x] Windows
- [x] Linux (VM)

